### PR TITLE
Fixed : "In MVC_Sample, JavaScript and CSS files should be referenced by Scripts.Render and Styles.Render" #33

### DIFF
--- a/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
+++ b/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
@@ -60,7 +60,8 @@ namespace MVC_Sample
                         "~/Content/themes/base/jquery.ui.tabs.css",
                         "~/Content/themes/base/jquery.ui.datepicker.css",
                         "~/Content/themes/base/jquery.ui.progressbar.css",
-                        "~/Content/themes/base/jquery.ui.theme.css"));
+                        "~/Content/themes/base/jquery.ui.theme.css",
+                        "~/Content/themes/base/jquery-ui.css"));
         }
     }
 }

--- a/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -7,13 +7,11 @@
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/modernizr")
-    <script src="~/Scripts/jquery-1.8.2.min.js"></script>
-    <script src="~/Scripts/jquery-ui-1.9.2.min.js"></script>
+    @Scripts.Render("~/bundles/jquery")
+    @Scripts.Render("~/bundles/jqueryui")
+    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
-    <link href="~/Content/themes/base/jquery-ui.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/jquery.ui.all.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/smoothness/jquery-ui-1.10.2.custom.css" rel="stylesheet" type="text/css" />
     @RenderSection("scripts", required: false)
 
     <script type="text/javascript">

--- a/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2012/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width" />
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
+    @Styles.Render("~/Content/themes/base/css")
     @Scripts.Render("~/bundles/modernizr")
     @Scripts.Render("~/bundles/jquery")
     @Scripts.Render("~/bundles/jqueryui")
-    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
     @RenderSection("scripts", required: false)

--- a/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
+++ b/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
@@ -60,7 +60,8 @@ namespace MVC_Sample
                         "~/Content/themes/base/jquery.ui.tabs.css",
                         "~/Content/themes/base/jquery.ui.datepicker.css",
                         "~/Content/themes/base/jquery.ui.progressbar.css",
-                        "~/Content/themes/base/jquery.ui.theme.css"));
+                        "~/Content/themes/base/jquery.ui.theme.css",
+                        "~/Content/themes/base/jquery-ui.css"));
         }
     }
 }

--- a/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -7,13 +7,11 @@
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/modernizr")
-    <script src="~/Scripts/jquery-1.8.2.min.js"></script>
-    <script src="~/Scripts/jquery-ui-1.9.2.min.js"></script>
+    @Scripts.Render("~/bundles/jquery")
+    @Scripts.Render("~/bundles/jqueryui")
+    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
-    <link href="~/Content/themes/base/jquery-ui.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/jquery.ui.all.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/smoothness/jquery-ui-1.10.2.custom.css" rel="stylesheet" type="text/css" />
     @RenderSection("scripts", required: false)
 
     <script type="text/javascript">

--- a/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2013/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width" />
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
+    @Styles.Render("~/Content/themes/base/css")
     @Scripts.Render("~/bundles/modernizr")
     @Scripts.Render("~/bundles/jquery")
     @Scripts.Render("~/bundles/jqueryui")
-    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
     @RenderSection("scripts", required: false)

--- a/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
+++ b/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/App_Start/BundleConfig.cs
@@ -60,7 +60,8 @@ namespace MVC_Sample
                         "~/Content/themes/base/jquery.ui.tabs.css",
                         "~/Content/themes/base/jquery.ui.datepicker.css",
                         "~/Content/themes/base/jquery.ui.progressbar.css",
-                        "~/Content/themes/base/jquery.ui.theme.css"));
+                        "~/Content/themes/base/jquery.ui.theme.css",
+                        "~/Content/themes/base/jquery-ui.css"));
         }
     }
 }

--- a/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -7,13 +7,11 @@
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/modernizr")
-    <script src="~/Scripts/jquery-1.8.2.min.js"></script>
-    <script src="~/Scripts/jquery-ui-1.9.2.min.js"></script>
+    @Scripts.Render("~/bundles/jquery")
+    @Scripts.Render("~/bundles/jqueryui")
+    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
-    <link href="~/Content/themes/base/jquery-ui.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/jquery.ui.all.css" rel="stylesheet" type="text/css" />
-    <link href="~/Content/themes/base/smoothness/jquery-ui-1.10.2.custom.css" rel="stylesheet" type="text/css" />
     @RenderSection("scripts", required: false)
 
     <script type="text/javascript">

--- a/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
+++ b/root_VS2015/programs/C#/Samples/WebApp_sample/MVC_Sample/MVC_Sample/Views/Shared/_CrudSampleLayout.cshtml
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width" />
     <title>@ViewBag.Title</title>
     @Styles.Render("~/Content/css")
+    @Styles.Render("~/Content/themes/base/css")
     @Scripts.Render("~/bundles/modernizr")
     @Scripts.Render("~/bundles/jquery")
     @Scripts.Render("~/bundles/jqueryui")
-    @Styles.Render("~/Content/themes/base/css")
     <script src="~/Framework/Js/common.js"></script>
     <script src="~/Scripts/jquery.unobtrusive-ajax.min.js"></script>
     @RenderSection("scripts", required: false)


### PR DESCRIPTION
fixed #33 

- Added Bundling feature for jQuery and CSS files used in MVC project.
- And also removed the unidentified CSS (jquery-ui-1.10.2.custom.css) link from the project.
