### PR TITLE
Fixed: "Error occurs when building portable class library with MSBuild #60"

### DIFF
--- a/root_VS2015/programs/C#/3_Build_PortableClassLibrary.bat
+++ b/root_VS2015/programs/C#/3_Build_PortableClassLibrary.bat
@@ -15,6 +15,11 @@ set CURRENT_DIR="%~dp0"
 @rem --------------------------------------------------
 call %CURRENT_DIR%z_Common.bat
 
+@rem --------------------------------------------------
+@rem Add environment variable to avoid build error.
+@rem --------------------------------------------------
+set VisualStudioVersion=12.0
+
 rem --------------------------------------------------
 rem Build the batch PortableClassLibrary(PortableClassLibrary)
 rem --------------------------------------------------


### PR DESCRIPTION
fixed #60 

- [Error occurs when building portable class library with MSBuild](https://github.com/OpenTouryoProject/OpenTouryoTemplates/issues/60)
